### PR TITLE
Fix #11 - regression causing crash when abs(p1.y - p2.y) < 1e10

### DIFF
--- a/poly2tri/common/shapes.h
+++ b/poly2tri/common/shapes.h
@@ -132,11 +132,11 @@ struct Edge {
     if (p1.y > p2.y) {
       q = &p1;
       p = &p2;
-    } else if (std::abs(p1.y - p2.y) < 1e-10) {
+    } else if (p1.y == p2.y) {
       if (p1.x > p2.x) {
         q = &p1;
         p = &p2;
-      } else if (std::abs(p1.x - p2.x) < 1e-10) {
+      } else if (p1.x == p2.x) {
         // Repeat points
         throw std::runtime_error("Edge::Edge: p1 == p2");
       }


### PR DESCRIPTION
This reverts commit e0ba327ed83f3e32933cf6cc4f61fabc50191711.

While the orignal commit silences a compiler warning, it introduces incorrect
behavior in Edge constructor that causes crash later during triangulation.

See #11 for an example of a simple polygon that would cause crash