### PR TITLE
Fix variable shadowing issue in Point's constructor. Shadowing causes…

### DIFF
--- a/poly2tri/common/shapes.h
+++ b/poly2tri/common/shapes.h
@@ -57,7 +57,7 @@ struct Point {
   std::vector<Edge*> edge_list;
 
   /// Construct using coordinates.
-  Point(double x, double y) : x(x), y(y) {}
+  Point(double x_, double y_) : x(x_), y(y_) {}
 
   /// Set this point to all zeros.
   void set_zero()


### PR DESCRIPTION
… can cause build failures when one's compiler is configured to flag shadowing as an error.