### PR TITLE
Add CMake files for the unit tests and the testbed app

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,12 +13,13 @@ jobs:
       image: fedora:32
     steps:
     - uses: actions/checkout@v2
+
     - name: Install dependencies
-      run: dnf install -yq cmake ninja-build gcc-c++ clang-tools-extra python3-PyYAML
+      run: dnf install -yq cmake ninja-build gcc-c++ clang-tools-extra python3-PyYAML boost-devel
 
     - name: Build with GCC
       run: |
-        cmake -Bbuild -GNinja
+        cmake -Bbuild -GNinja -DP2T_BUILD_TESTS=ON
         cmake --build build
 
     - name: Build with Clang
@@ -28,3 +29,6 @@ jobs:
 
     - name: Lint with clang-tidy
       run: python3 /usr/share/clang/run-clang-tidy.py -header-filter=poly2tri -p=build-clang
+
+    - name: Unit tests
+      run: cd build && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 
 project(poly2tri LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 
+option(P2T_BUILD_TESTS "Build tests" OFF)
+
 file(GLOB SOURCES poly2tri/common/*.cc poly2tri/sweep/*.cc)
 add_library(poly2tri ${SOURCES})
 target_include_directories(poly2tri INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(P2T_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(unittest)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(poly2tri LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 
 option(P2T_BUILD_TESTS "Build tests" OFF)
+option(P2T_BUILD_TESTBED "Build the testbed application" OFF)
 
 file(GLOB SOURCES poly2tri/common/*.cc poly2tri/sweep/*.cc)
 add_library(poly2tri ${SOURCES})
@@ -12,4 +13,8 @@ target_include_directories(poly2tri INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 if(P2T_BUILD_TESTS)
     enable_testing()
     add_subdirectory(unittest)
+endif()
+
+if(P2T_BUILD_TESTBED)
+    add_subdirectory(testbed)
 endif()

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ lib = static_library('poly2tri', sources : [
 ])
 
 thread_dep = dependency('threads')
-boost_test_dep = dependency('boost', modules : [ 'unit_test_framework' ], required : false)
+boost_test_dep = dependency('boost', modules : [ 'filesystem', 'unit_test_framework' ], required : false)
 if boost_test_dep.found()
 	test('Unit Test', executable('unittest', [
 		'unittest/main.cpp',

--- a/testbed/CMakeLists.txt
+++ b/testbed/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Dependencies
+find_package(glfw3 3.3 REQUIRED)
+find_package(OpenGL REQUIRED)
+
+# Build testbed
+add_executable(testbed
+    main.cc
+)
+
+target_link_libraries(testbed
+    PRIVATE
+    glfw
+    OpenGL::GL
+    poly2tri
+)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Dependencies
+if (WIN32)
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
+find_package(Boost 1.69 REQUIRED COMPONENTS
+    filesystem
+    unit_test_framework
+)
+
+# Build Unit Tests
+add_executable(test_poly2tri
+    main.cpp
+    TriangleTest.cpp
+)
+
+target_include_directories(test_poly2tri
+    PRIVATE
+    ${Boost_INCLUDE_DIRS}
+)
+
+target_compile_definitions(test_poly2tri
+    PRIVATE
+    P2T_BASE_DIR="${PROJECT_SOURCE_DIR}"
+)
+
+target_link_libraries(test_poly2tri
+    PRIVATE
+    poly2tri
+    ${Boost_LIBRARIES}
+)
+
+add_test(NAME poly2tri COMMAND test_poly2tri)

--- a/unittest/TriangleTest.cpp
+++ b/unittest/TriangleTest.cpp
@@ -1,3 +1,6 @@
+#ifndef WIN32
+#define BOOST_TEST_DYN_LINK
+#endif
 #include <boost/test/unit_test.hpp>
 #include <poly2tri/common/shapes.h>
 

--- a/unittest/main.cpp
+++ b/unittest/main.cpp
@@ -1,5 +1,9 @@
+#ifndef WIN32
 #define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE Poly2triTest
+
+#include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>
 #include <poly2tri/poly2tri.h>
 #include <fstream>
@@ -64,9 +68,13 @@ BOOST_AUTO_TEST_CASE(TestbedFilesTest)
     // Load pointset from file
     // Parse and tokenize data file
     std::string line;
-    const std::string src(__FILE__); // ../unittest/main.cpp
-    auto folder = src.substr(0, src.find_last_of('/')) + "/../testbed/data/";
-    std::ifstream myfile(folder + filename);
+#ifndef P2T_BASE_DIR
+    const auto basedir = boost::filesystem::path(__FILE__).remove_filename().parent_path();
+#else
+    const auto basedir = boost::filesystem::path(P2T_BASE_DIR);
+#endif
+    const auto datafile = basedir / boost::filesystem::path("testbed/data") / boost::filesystem::path(filename);
+    std::ifstream myfile(datafile.string());
     BOOST_REQUIRE(myfile.is_open());
     while (!myfile.eof()) {
       getline(myfile, line);


### PR DESCRIPTION
In those commits building the unit tests and the testbed via cmake is optional, OFF by default, to prevent the clients of the library from pulling their dependencies (boost, glfw, etc.)

Running the unit tests was added to the Github Actions.

A note for Windows users:
The tesbed has a dependency on GLFW, and CMake was not able find the package glfw3 from the pre-compiled binaries available for version 3.3.2, I ended up doing the following:
- Build GLFW from sources.
- Make the 'install' target as well (which will generate the proper cmake files, glfw3Config.cmake, glfw3Targets.cmake, etc.)
- Set the glfw3_ROOT env variable to point to the cmake files.
- find_package(glfw3 3.3 REQUIRED) should now work.

