### PR TITLE
Avoid triggering Werror=float-equal

### DIFF
--- a/poly2tri/common/shapes.h
+++ b/poly2tri/common/shapes.h
@@ -34,9 +34,13 @@
 #define SHAPES_H
 
 #include <cmath>
+#include <cfloat>
 #include <cstddef>
 #include <stdexcept>
 #include <vector>
+
+/* Avoid Werror=float-equal warnings */
+#define EQ(v1, v2) ((v1 - v2 > -DBL_MIN) && (v1 - v2 < DBL_MIN))
 
 namespace p2t {
 
@@ -132,11 +136,11 @@ struct Edge {
     if (p1.y > p2.y) {
       q = &p1;
       p = &p2;
-    } else if (p1.y == p2.y) {
+    } else if (EQ(p1.y, p2.y)) {
       if (p1.x > p2.x) {
         q = &p1;
         p = &p2;
-      } else if (p1.x == p2.x) {
+      } else if (EQ(p1.x, p2.x)) {
         // Repeat points
         throw std::runtime_error("Edge::Edge: p1 == p2");
       }
@@ -225,7 +229,7 @@ inline bool cmp(const Point* a, const Point* b)
 {
   if (a->y < b->y) {
     return true;
-  } else if (a->y == b->y) {
+  } else if (EQ(a->y, b->y)) {
     // Make sure q is point with greater x value
     if (a->x < b->x) {
       return true;
@@ -254,12 +258,12 @@ inline Point operator *(double s, const Point& a)
 
 inline bool operator ==(const Point& a, const Point& b)
 {
-  return a.x == b.x && a.y == b.y;
+  return EQ(a.x, b.x) && EQ(a.y, b.y);
 }
 
 inline bool operator !=(const Point& a, const Point& b)
 {
-  return !(a.x == b.x) || !(a.y == b.y);
+  return !(EQ(a.x, b.x)) || !(EQ(a.y, b.y));
 }
 
 /// Peform the dot product on two vectors.


### PR DESCRIPTION
Our code uses the Werror=float-equal warning, which trips on the shapes.h header.  This is an attempt to work around triggering that warning.