### PR TITLE
File naming, build/run instruction updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Core poly2tri lib:
 
 * Standard Template Library (STL)
 
+Unit tests:
+* Boost (filesystem, test framework)
+
 Testbed:
 
 * OpenGL

--- a/README.md
+++ b/README.md
@@ -72,19 +72,19 @@ Running the Examples
 
 Load data points from a file:
 ```
-p2t <filename> <center_x> <center_y> <zoom>
+build/testbed/p2t <filename> <center_x> <center_y> <zoom>
 ```
 Random distribution of points inside a constrained box:
 ```
-p2t random <num_points> <box_radius> <zoom>
+build/testbed/p2t random <num_points> <box_radius> <zoom>
 ```
 Examples:
 ```
-./build/p2t testbed/data/dude.dat 300 500 2
-./build/p2t testbed/data/nazca_monkey.dat 0 0 9
+build/testbed/p2t testbed/data/dude.dat 300 500 2
+build/testbed/p2t testbed/data/nazca_monkey.dat 0 0 9
 
-./build/p2t random 10 100 5.0
-./build/p2t random 1000 20000 0.025
+build/testbed/p2t random 10 100 5.0
+build/testbed/p2t random 1000 20000 0.025
 ```
 
 References

--- a/README.md
+++ b/README.md
@@ -38,28 +38,32 @@ Testbed:
 Build the library
 -----------------
 
+With the ninja build system installed:
+
 ```
 mkdir build && cd build
-cmake -GNinja
+cmake -GNinja ..
 cmake --build .
 ```
 
-Build and run the unit tests
+Build and run with unit tests
 ----------------------------
+
+With the ninja build system:
 
 ```
 mkdir build && cd build
-cmake -GNinja -DP2T_BUILD_TESTS=ON
+cmake -GNinja -DP2T_BUILD_TESTS=ON ..
 cmake --build .
 ctest --output-on-failure
 ```
 
-Build the testbed
+Build with the testbed
 -----------------
 
 ```
 mkdir build && cd build
-cmake -GNinja -DP2T_BUILD_TESTBED=ON
+cmake -GNinja -DP2T_BUILD_TESTBED=ON ..
 cmake --build .
 ```
 

--- a/testbed/CMakeLists.txt
+++ b/testbed/CMakeLists.txt
@@ -3,11 +3,11 @@ find_package(glfw3 3.3 REQUIRED)
 find_package(OpenGL REQUIRED)
 
 # Build testbed
-add_executable(testbed
+add_executable(p2t
     main.cc
 )
 
-target_link_libraries(testbed
+target_link_libraries(p2t
     PRIVATE
     glfw
     OpenGL::GL


### PR DESCRIPTION
I thought a few of the build instructions, as well as the testbed executable naming, could be made clearer.  All my suggestions here are debatable, so I broke them into separate commits in case you might want to merge some but not others.