### PR TITLE
Disable collinearity tolerance

### DIFF
--- a/poly2tri/common/utils.h
+++ b/poly2tri/common/utils.h
@@ -68,7 +68,10 @@ Orientation Orient2d(const Point& pa, const Point& pb, const Point& pc)
   double detleft = (pa.x - pc.x) * (pb.y - pc.y);
   double detright = (pa.y - pc.y) * (pb.x - pc.x);
   double val = detleft - detright;
-  if (val > -EPSILON && val < EPSILON) {
+
+// Using a tolerance here fails on concave-by-subepsilon boundaries
+//   if (val > -EPSILON && val < EPSILON) {
+  if (val == 0) {
     return COLLINEAR;
   } else if (val > 0) {
     return CCW;

--- a/poly2tri/common/utils.h
+++ b/poly2tri/common/utils.h
@@ -71,7 +71,8 @@ Orientation Orient2d(const Point& pa, const Point& pb, const Point& pc)
 
 // Using a tolerance here fails on concave-by-subepsilon boundaries
 //   if (val > -EPSILON && val < EPSILON) {
-  if (val == 0) {
+// Using == on double makes -Wfloat-equal warnings yell at us
+  if (std::fpclassify(val) == FP_ZERO) {
     return COLLINEAR;
   } else if (val > 0) {
     return CCW;

--- a/unittest/main.cpp
+++ b/unittest/main.cpp
@@ -49,7 +49,8 @@ BOOST_AUTO_TEST_CASE(QuadTest)
 
 BOOST_AUTO_TEST_CASE(NarrowQuadTest)
 {
-  // Very narrow quad that demonstrates a failure case during triangulation
+  // Very narrow quad that used to demonstrate a failure case during
+  // triangulation
   std::vector<p2t::Point*> polyline {
     new p2t::Point(0.0,     0.0),
     new p2t::Point(1.0e-05, 0.0),
@@ -57,7 +58,10 @@ BOOST_AUTO_TEST_CASE(NarrowQuadTest)
     new p2t::Point(1.0e-04, 3.0e-07)
   };
   p2t::CDT cdt{ polyline };
-  BOOST_CHECK_THROW(cdt.Triangulate(), std::runtime_error);
+  BOOST_CHECK_NO_THROW(cdt.Triangulate());
+  const auto result = cdt.GetTriangles();
+  BOOST_REQUIRE_EQUAL(result.size(), 2);
+  BOOST_CHECK(p2t::IsDelaunay(result));
   for (const auto p : polyline) {
     delete p;
   }


### PR DESCRIPTION
This is a naive way to fix #39 ... but at least for my cases, it works!

When I ran the poly2tri unit test suite, I got a failure ... but it turned out that the "failure" was that it stopped failing in a test that had previously been failing, so I'm going to call that a success instead and change the test to assert so.

I've added a new unit test too, with the original problem from #39 (rewritten to match the coding style of the other tests more closely), so even if it turns out that the Orient2d change isn't the best fix here, we can make sure subsequent fixes don't revert that progress.

With this in place my refinement code seems to be working, so I'll start conjuring up a bunch of test cases via that and see if I can trigger any other bugs that this fix missed or any previously-non-bug cases that this fix regressed.