### PR TITLE
Return by reference and const overloads

### DIFF
--- a/poly2tri/common/shapes.h
+++ b/poly2tri/common/shapes.h
@@ -161,6 +161,7 @@ bool constrained_edge[3];
 bool delaunay_edge[3];
 
 Point* GetPoint(int index);
+const Point* GetPoint(int index) const;
 Point* PointCW(const Point& point);
 Point* PointCCW(const Point& point);
 Point* OppositePoint(Triangle& t, const Point& p);
@@ -288,9 +289,15 @@ inline Point Cross(double s, const Point& a)
   return Point(-s * a.y, s * a.x);
 }
 
-inline Point* Triangle::GetPoint(int index)
+inline const Point* Triangle::GetPoint(int index) const
 {
   return points_[index];
+}
+
+inline Point* Triangle::GetPoint(int index)
+{
+  return const_cast<Point*>(
+      static_cast<const Triangle&>(*this).GetPoint(index));
 }
 
 inline Triangle* Triangle::GetNeighbor(int index)

--- a/poly2tri/sweep/cdt.cc
+++ b/poly2tri/sweep/cdt.cc
@@ -52,12 +52,12 @@ void CDT::Triangulate()
   sweep_->Triangulate(*sweep_context_);
 }
 
-std::vector<p2t::Triangle*> CDT::GetTriangles()
+const std::vector<p2t::Triangle*>& CDT::GetTriangles() const
 {
   return sweep_context_->GetTriangles();
 }
 
-std::list<p2t::Triangle*> CDT::GetMap()
+const std::list<p2t::Triangle*>& CDT::GetMap() const
 {
   return sweep_context_->GetMap();
 }

--- a/poly2tri/sweep/cdt.h
+++ b/poly2tri/sweep/cdt.h
@@ -83,12 +83,12 @@ public:
   /**
    * Get CDT triangles
    */
-  std::vector<Triangle*> GetTriangles();
+  const std::vector<Triangle*>& GetTriangles() const;
 
   /**
    * Get triangle map
    */
-  std::list<Triangle*> GetMap();
+  const std::list<Triangle*>& GetMap() const;
 
   private:
 

--- a/poly2tri/sweep/sweep_context.cc
+++ b/poly2tri/sweep/sweep_context.cc
@@ -57,12 +57,24 @@ void SweepContext::AddPoint(Point* point) {
   points_.push_back(point);
 }
 
-std::vector<Triangle*> &SweepContext::GetTriangles()
+std::vector<Triangle*>& SweepContext::GetTriangles()
+{
+  return const_cast<std::vector<Triangle*>&>(
+      static_cast<const SweepContext&>(*this).GetTriangles());
+}
+
+const std::vector<Triangle*>& SweepContext::GetTriangles() const
 {
   return triangles_;
 }
 
-std::list<Triangle*> &SweepContext::GetMap()
+std::list<Triangle*>& SweepContext::GetMap()
+{
+  return const_cast<std::list<Triangle*>&>(
+    static_cast<const SweepContext&>(*this).GetMap());
+}
+
+const std::list<Triangle*>& SweepContext::GetMap() const
 {
   return map_;
 }

--- a/poly2tri/sweep/sweep_context.h
+++ b/poly2tri/sweep/sweep_context.h
@@ -91,7 +91,9 @@ AdvancingFront* front() const;
 void MeshClean(Triangle& triangle);
 
 std::vector<Triangle*> &GetTriangles();
+const std::vector<Triangle*> &GetTriangles() const;
 std::list<Triangle*> &GetMap();
+const std::list<Triangle*> &GetMap() const;
 
 std::vector<Edge*> edge_list;
 


### PR DESCRIPTION
This PR adds a `const` overload of `GetPoint` (that returns a `const Point*`) and updates `GetTriangles` and `GetMap` to return a `const` reference to the underlying data structure as opposed to returning by value (and forcing a copy).

A copy can still be made by not using a `const` ref variable.

e.g.

```c++
std::vector<p2t::Triangle*> triangles = cdt.GetTriangles(); // copy
const std::vector<p2t::Triangle*>& triangles = cdt.GetTriangles(); // no copy
```

I held off making any further changes to keep the PR small and simple. There are a few more spots that could benefit from `const` but it's not critical by any means.

Also to reduce duplication in the `const`/non-`const` overloads, I used the solution popularized by Scott Meyers in Effective C++ (Item 3) - see https://stackoverflow.com/a/123995/1947066 for details (I'm happy to change this to duplicate the logic in both overloads if you think that is clearer, or add a comment to explain what is being done and why).

Great library and I hope this incredibly minor contribution is helpful,

Thanks!