### PR TITLE
Fix invalid UTF-8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 Primary Contributors:
 
   Mason Green <mason.green@gmail.com> (C++, Python)
-  Thomas Åhlén <thahlen@gmail.com>    (Java)
+  Thomas Ã…hlÃ©n <thahlen@gmail.com>    (Java)
 
 Other Contributors:
 

--- a/poly2tri/sweep/sweep.h
+++ b/poly2tri/sweep/sweep.h
@@ -33,7 +33,7 @@
  * Zalik, B.(2008)'Sweep-line algorithm for constrained Delaunay triangulation',
  * International Journal of Geographical Information Science
  *
- * "FlipScan" Constrained Edge Algorithm invented by Thomas Åhlén, thahlen@gmail.com
+ * "FlipScan" Constrained Edge Algorithm invented by Thomas Ã…hlÃ©n, thahlen@gmail.com
  */
 
 #pragma once


### PR DESCRIPTION
I have fixed two instances of invalid UTF-8 characters. Also reported by Clang 16 with flag `-Wpedantic`:
```
/home/afforix/devel/poly2tri/poly2tri/sweep/sweep.h:36:61: warning: invalid UTF-8 in comment [-Winvalid-utf8]
 * "FlipScan" Constrained Edge Algorithm invented by Thomas <C5>hl<E9>n, thahlen@gmail.com
                                                            ^
```