### PR TITLE
Add missing iosfwd include

### DIFF
--- a/poly2tri/common/shapes.h
+++ b/poly2tri/common/shapes.h
@@ -35,6 +35,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <iosfwd>
 #include <stdexcept>
 #include <vector>
 


### PR DESCRIPTION
Newer versions of libc++ are better about avoiding standard library header pollution, so the `std::ostream` usage no longer compiles without explicitly adding `#include <iosfwd>`